### PR TITLE
R package management docs

### DIFF
--- a/doc/jupyter-dependency-management.md
+++ b/doc/jupyter-dependency-management.md
@@ -1,4 +1,7 @@
-# Python dependency management for JupyterLab projects
+# Dependency management for JupyterLab projects
+When using JupyterLab, we sometimes need to install and use different/specific packages on a per-project basis. We need to do this both for Python and for R projects.
+
+# Python dependency management
 
 It is possible to use different Python packages and different versions of packages for different JupyterLab projects, and automatically keep track of which versions of which packages were used in the project at any given time. This is achieved by creating a Python virtual environment for each project, and creating a new Jupyter kernel that utilizes the virtual environment. 
 
@@ -67,8 +70,33 @@ Delete the named kernel only, not the pipenv or pipfiles.
 Delete pipenv files associated to current project (`pipenv --venv` to display path) from the user home folder. This part can easily be re-generated from the `Pipfile` and `Pipfile.lock` located in the project folder, which are not deleted by default.
 The `--hard` option deletes `Pipfile` and `Pipfile.lock` from project folder too, so that all dependency tracking is lost.
 
-## Enabling Spark in a custom kernel
+### Enabling Spark in a custom kernel
 
 If you want to be able to run Spark code using a pipenv-kernel setup, you must use one of the Spark kernels as your template kernel, AND you must run `pipenv install ssb-ipython-kernels` in your project folder. As of 20/04/2021 you might have to `pipenv install jwt` too, but this should not be necessary in the future.
 
+# R dependency management
+
+## Virtual environments
+
+To create a virtual environment for your project, run these from an R session/notebook inside the project folder:
+
+`library(renv)`
+
+`renv::init()`
+
+A folder called "renv" containing your virtual environment with its own library should now have been created next to the notebook from which you ran the `renv::init()` command. You can now install, uninstall and load packages as usual. To save a list of your dependencies into a lockfile, use `renv::snapshot()`, and to restore the environment from this lockfile, use `renv::restore()`. Read the complete [renv documentation here](https://rstudio.github.io/renv/articles/renv.html). NB!: `renv::snapshot()` does not currently support `.ipynb` files (only `.R` and `Rmd`). The lockfile produced by `renv::snapshot()` will therefore not be sufficient to reproduce your virtual environment in itself. One way to solve this is to create a `dependencies.R` file where you install and load all the packages needed in your notebook, and then at the beginning of your notebook call `source("dependencies.R")`
+
+## Installing and loading packages, as usual
+
+To list your R libraries (folders containing installed packages)
+
+`.libPaths()`
+
+To install a new package into one of your libraries, use
+
+`packages.install("package", lib="/path/to/lib")` where the "lib" argument is optional and used to select a non-default library path. The default library path will be the first one, which in case you use `renv` should be your project local library.
+
+When loading an already downloaded/installed package from one of your registered R libraries (folders on your machine already containing downloaded packages) into a notebook, all you need to do is
+
+`library(package)`
 

--- a/doc/jupyter-dependency-management.md
+++ b/doc/jupyter-dependency-management.md
@@ -128,7 +128,7 @@ When loading an already downloaded/installed package from one of your registered
 
 As explained, using the `renv::snapshot()` function will generate a `renv.lock` file which will describe your project's dependencies. In order to restore the virtual environment from a `renv.lock` file you need to use the function `renv::restore()`.
 
-If you have an accurate `renv.lock` file from which you can `renv::restore()`, you do not need to run `source(here::here('dependencies.R'))` at the beginning of your notebook. In other words, you can replace
+If you have an accurate `renv.lock` file from which you can `renv::restore()`, you do not need to run `source(here::here('dependencies.R'))` at the beginning of your notebook. In other words, if you used a `dependencies.R` file to load packages initially, you can now replace
 
 `source(here::here('dependencies.R'))`
 

--- a/doc/jupyter-dependency-management.md
+++ b/doc/jupyter-dependency-management.md
@@ -89,7 +89,7 @@ A folder called "renv" containing your virtual environment with its own library 
 ---
 **NOTE!**
 
-`renv::snapshot()` does not currently manage to extract dependencies from `.ipynb` files (only `.R` and `.Rmd`). The lockfile produced by `renv::snapshot()` will therefore not be sufficient to reproduce your virtual environment in itself. One way to solve this is to create a `dependencies.R` file (or perhaps one for each notebook) where you install and load all the packages needed in your project notebook(s), and then at the beginning of your notebook load and resolve packages using this line at the beginning of your notebook
+`renv::snapshot()` does not currently manage to extract dependencies from `.ipynb` files (only `.R` and `.Rmd`). The lockfile produced by `renv::snapshot()` will therefore not be sufficient to reproduce your virtual environment in itself. One way to solve this is to create a `dependencies.R` file (or perhaps one for each notebook) where you install and load all the packages needed in your project notebook(s), and then at the beginning of your notebook load and resolve packages using this line:
 
 `source(here::here('dependencies.R'))`
 
@@ -97,8 +97,6 @@ An example `dependencies.R`
 
 ```
 # Initialize the virtual environment
-install.packages("renv")
-library(renv)
 renv::init()
 
 # Packages go here
@@ -126,3 +124,16 @@ When loading an already downloaded/installed package from one of your registered
 
 `library(package)`
 
+## Restoring a renv virtual environment from a lockfile
+
+As explained, using the `renv::snapshot()` function will generate a `renv.lock` file which will describe your project's dependencies. In order to restore the virtual environment from a `renv.lock` file you need to use the function `renv::restore()`.
+
+If you have an accurate `renv.lock` file from which you can `renv::restore()`, you do not need to run `source(here::here('dependencies.R'))` at the beginning of your notebook. In other words, you can replace
+
+`source(here::here('dependencies.R'))`
+
+with
+
+`renv::restore()`
+
+when your dependencies have been locked.

--- a/doc/jupyter-dependency-management.md
+++ b/doc/jupyter-dependency-management.md
@@ -84,7 +84,33 @@ To create a virtual environment for your project, run these from an R session/no
 
 `renv::init()`
 
-A folder called "renv" containing your virtual environment with its own library should now have been created next to the notebook from which you ran the `renv::init()` command. You can now install, uninstall and load packages as usual. To save a list of your dependencies into a lockfile, use `renv::snapshot()`, and to restore the environment from this lockfile, use `renv::restore()`. Read the complete [renv documentation here](https://rstudio.github.io/renv/articles/renv.html). NB!: `renv::snapshot()` does not currently support `.ipynb` files (only `.R` and `Rmd`). The lockfile produced by `renv::snapshot()` will therefore not be sufficient to reproduce your virtual environment in itself. One way to solve this is to create a `dependencies.R` file where you install and load all the packages needed in your notebook, and then at the beginning of your notebook call `source("dependencies.R")`
+A folder called "renv" containing your virtual environment with its own library should now have been created next to the notebook from which you ran the `renv::init()` command. You can now install, uninstall and load packages as usual. To save a list of your dependencies into a lockfile, use `renv::snapshot()`, and to restore the environment from this lockfile, use `renv::restore()`. Read the complete [renv documentation here](https://rstudio.github.io/renv/articles/renv.html). 
+
+---
+**NOTE!**
+
+`renv::snapshot()` does not currently manage to extract dependencies from `.ipynb` files (only `.R` and `.Rmd`). The lockfile produced by `renv::snapshot()` will therefore not be sufficient to reproduce your virtual environment in itself. One way to solve this is to create a `dependencies.R` file (or perhaps one for each notebook) where you install and load all the packages needed in your project notebook(s), and then at the beginning of your notebook load and resolve packages using this line at the beginning of your notebook
+
+`source(here::here('dependencies.R'))`
+
+An example `dependencies.R`
+
+```
+# Initialize the virtual environment
+install.packages("renv")
+library(renv)
+renv::init()
+
+# Packages go here
+install.packages("lattice")
+library(lattice)
+
+# Save the dependencies to renv.lock
+renv::snapshot()
+
+```
+
+---
 
 ## Installing and loading packages, as usual
 

--- a/doc/jupyter-dependency-management.md
+++ b/doc/jupyter-dependency-management.md
@@ -97,6 +97,7 @@ An example `dependencies.R`
 
 ```
 # Initialize the virtual environment
+library(renv)
 renv::init()
 
 # Packages go here
@@ -112,13 +113,13 @@ renv::snapshot()
 
 ## Installing and loading packages, as usual
 
-To list your R libraries (folders containing installed packages)
+To list all installed packages from all libraries, use
 
-`.libPaths()`
+`installed.packages()`
 
-To install a new package into one of your libraries, use
+When installing a new package from CRAN that is not present, use
 
-`packages.install("package", lib="/path/to/lib")` where the "lib" argument is optional and used to select a non-default library path. The default library path will be the first one, which in case you use `renv` should be your project local library.
+`install.packages("packagename")`
 
 When loading an already downloaded/installed package from one of your registered R libraries (folders on your machine already containing downloaded packages) into a notebook, all you need to do is
 


### PR DESCRIPTION
R package management per project is now possible, and we can generate accurate `renv.lock` files that can be used to reproduce the virtual environment from scratch, but it requires a certain setup using a separate `dependencies.R` file. This documentation is intended to explain the "why" and "how" of this system to users of JupyterLab.

Partially solves https://statistics-norway.atlassian.net/browse/DAPLA-111. The only thing remaining is to hold a live demo and/or create a short video demo of the functionality.